### PR TITLE
- Media view on facebook native ad ios

### DIFF
--- a/proj.android_studio/ee-x-facebook-ads/src/main/java/com/ee/facebook/FacebookNativeAd.java
+++ b/proj.android_studio/ee-x-facebook-ads/src/main/java/com/ee/facebook/FacebookNativeAd.java
@@ -44,6 +44,7 @@ class FacebookNativeAd implements AdListener, IAdView {
     private static final String k__media          = "media";
     private static final String k__social_context = "social_context";
     private static final String k__title          = "title";
+    private static final String k__cover          = "cover";
 
     private static final String k__tag = "FacebookNativeAd";
 
@@ -345,6 +346,7 @@ class FacebookNativeAd implements AdListener, IAdView {
             public void process(MediaView view) {
                 // Download and display the cover image.
                 view.setNativeAd(_nativeAd);
+
             }
         });
 
@@ -360,6 +362,14 @@ class FacebookNativeAd implements AdListener, IAdView {
             public void process(TextView view) {
                 view.setText(_nativeAd.getAdTitle());
                 clickableViews.add(view);
+            }
+        });
+
+        processView(_nativeAdView, k__cover, new ViewProcessor<ImageView>() {
+            @Override
+            public void process(ImageView view) {
+                NativeAd.Image adCover = _nativeAd.getAdCoverImage();
+                NativeAd.downloadAndDisplayImage(adCover, view);
             }
         });
 

--- a/src/ee/facebookads/EEFacebookAds.h
+++ b/src/ee/facebookads/EEFacebookAds.h
@@ -22,7 +22,8 @@ typedef struct FBAdSize FBAdSize;
 - (BOOL)destroyBannerAd:(NSString* _Nonnull)adId;
 
 - (BOOL)createNativeAd:(NSString* _Nonnull)adId
-                layout:(NSString* _Nonnull)layout;
+                layout:(NSString* _Nonnull)layout
+           identifiers:(NSDictionary* _Nonnull)identifiers;
 - (BOOL)destroyNativeAd:(NSString* _Nonnull)adId;
 
 - (BOOL)createInterstitialAd:(NSString* _Nonnull)placementId;

--- a/src/ee/facebookads/EEFacebookAds.m
+++ b/src/ee/facebookads/EEFacebookAds.m
@@ -58,6 +58,7 @@ static NSString* const k__destroyRewardVideoAd  = @"FacebookAds_destroyRewardVid
 static NSString* const k__ad_id                 = @"ad_id";
 static NSString* const k__ad_size               = @"ad_size";
 static NSString* const k__layout_name           = @"layout_name";
+static NSString* const k__identifiers           = @"identifiers";
 // clang-format on
 
 - (id)init {
@@ -128,8 +129,9 @@ static NSString* const k__layout_name           = @"layout_name";
                        [EEJsonUtils convertStringToDictionary:message];
                    NSString* adId = dict[k__ad_id];
                    NSString* layoutName = dict[k__layout_name];
+                   NSDictionary* identifiers = dict[k__identifiers];
                    return [EEUtils
-                       toString:[self createNativeAd:adId layout:layoutName]];
+                       toString:[self createNativeAd:adId layout:layoutName identifiers: identifiers]];
                }];
 
     [bridge_ registerHandler:k__destroyNativeAd
@@ -218,14 +220,17 @@ static NSString* const k__layout_name           = @"layout_name";
     return YES;
 }
 
-- (BOOL)createNativeAd:(NSString*)adId layout:(NSString*)layout {
+- (BOOL)createNativeAd:(NSString*)adId
+                layout:(NSString*)layout
+           identifiers:(NSDictionary* _Nonnull)identifiers {
     if ([nativeAds_ objectForKey:adId] != nil) {
         return NO;
     }
     EEFacebookNativeAd* ad =
         [[[EEFacebookNativeAd alloc] initWithBridge:bridge_
                                                adId:adId
-                                             layout:layout] autorelease];
+                                             layout:layout
+                                        identifiers:identifiers] autorelease];
     [nativeAds_ setObject:ad forKey:adId];
     return YES;
 }

--- a/src/ee/facebookads/FacebookNativeAdLayout.cpp
+++ b/src/ee/facebookads/FacebookNativeAdLayout.cpp
@@ -21,6 +21,8 @@ constexpr auto k__icon           = "icon";
 constexpr auto k__media          = "media";
 constexpr auto k__social_context = "social_context";
 constexpr auto k__title          = "title";
+constexpr auto k__cover          = "cover";
+constexpr auto k__sponsor        = "sponsor";
 // clang-format on
 } // namespace
 
@@ -60,6 +62,16 @@ Self& Self::setSocialContext(const std::string& id) {
 
 Self& Self::setTitle(const std::string& id) {
     params_[k__title] = id;
+    return *this;
+}
+
+Self& Self::setCover(const std::string& id) {
+    params_[k__cover] = id;
+    return *this;
+}
+
+Self& Self::setSponsor(const std::string &id) {
+    params_[k__sponsor] = id;
     return *this;
 }
 } // namespace facebook

--- a/src/ee/facebookads/FacebookNativeAdLayout.hpp
+++ b/src/ee/facebookads/FacebookNativeAdLayout.hpp
@@ -23,7 +23,7 @@ private:
 public:
     NativeAdLayout();
     ~NativeAdLayout();
-
+    
     Self& setAdChoices(const std::string& id);
     Self& setBody(const std::string& id);
     Self& setCallToAction(const std::string& id);
@@ -31,7 +31,8 @@ public:
     Self& setMedia(const std::string& id);
     Self& setSocialContext(const std::string& id);
     Self& setTitle(const std::string& id);
-
+    Self& setCover(const std::string& id);
+    Self& setSponsor(const std::string& id);
 private:
     friend FacebookAds;
 

--- a/src/ee/facebookads/internal/EEFacebookNativeAd.h
+++ b/src/ee/facebookads/internal/EEFacebookNativeAd.h
@@ -14,7 +14,8 @@
 
 - (id _Nonnull)initWithBridge:(id<EEIMessageBridge>)bridge
                          adId:(NSString* _Nonnull)adId
-                       layout:(NSString* _Nonnull)layoutName;
+                       layout:(NSString* _Nonnull)layoutName
+                  identifiers:(NSDictionary* _Nonnull)identifiers;
 
 - (void)destroy;
 


### PR DESCRIPTION
- Add media view on facebook native ad and automatically hide cover image view when the ad having media content

- Auto hide subview if the layout does not mention to it